### PR TITLE
Add @angular/material 9 as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "yargs": "^13.3.0"
   },
   "peerDependencies": {
-    "@angular/material": "^7.0.0 || ^8.0.0"
+    "@angular/material": "^7.0.0 || ^8.0.0 || ^9.0.0"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
In order to avoid warnings using Angular 9, changed peerDependencies in package.json.
I dond't know a better way... so add another OR with 9 version